### PR TITLE
Fix `403 Insufficient OAuth2 scope to perform this operation.` error

### DIFF
--- a/osrm/files/gcs-download-prepared.sh.tpl
+++ b/osrm/files/gcs-download-prepared.sh.tpl
@@ -19,6 +19,7 @@ mkdir -p "/data/maps/${version}"
 cd "/data/maps/${version}"
 
 if [ ! -r downloaded.lock ]; then
+  gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
   gsutil -m cp "${uri}" .
   tar xzvf "${file}"
   rm "${file}"


### PR DESCRIPTION
It seems that `gcloud` (`gsutil` as well) doesn't honor the full application default credentials specification and needs it's own configuration files. This leads to the `403 Insufficient OAuth2 scope to perform this operation.` error from init container that runs `gcs-download-prepared.sh`. So far I've found two possible solutions for the issue: run `gcloud auth activate-service-account --key-file=/path/to/credentials.json` either set `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=/path/to/credentials.json` and `CLOUDSDK_CORE_PROJECT=project-name`. The latter requires the project name therefore I've chosen the former for this PR.

See https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/152 for extra details on the issue.